### PR TITLE
Fix overly-specific HAL includes

### DIFF
--- a/ILI9341/ili9341.h
+++ b/ILI9341/ili9341.h
@@ -14,15 +14,15 @@ extern "C" {
 
 // ----------------------------------------------------------------- includes --
 
-#if defined (STM32L476xx)
+#if defined (STM32L4)
 #include "stm32l4xx_hal.h"
-#elif defined(STM32F072xx)
+#elif defined(STM32F0)
 #include "stm32f0xx_hal.h"
-#elif defined(STM32F401xx)
+#elif defined(STM32F4)
 #include "stm32f4xx_hal.h"
-#elif defined(STM32G431xx)
+#elif defined(STM32G4)
 #include "stm32g4xx_hal.h"
-#elif defined(STM32G031xx)
+#elif defined(STM32G0)
 #include "stm32g0xx_hal.h"
 #endif
 


### PR DESCRIPTION
Fix overly-specific HAL includes

Include HAL based on Family instead of specific microcontrollers.